### PR TITLE
update: add dYdX on Kaon.

### DIFF
--- a/dydx-mainnet-1/config.yml
+++ b/dydx-mainnet-1/config.yml
@@ -1,0 +1,13 @@
+# Global information
+source:
+    title: "dYdY"
+    chain_id: "dydx-mainnet-1"
+    hex: "#12121d"
+
+# Mainnet pools
+kyve-1: {}
+
+# Testnet pools
+kaon-1:
+    block_pool_id: 8
+    state_pool_id: 9


### PR DESCRIPTION
This PR registers the **dYdY** source containing a `kyvejs/tendermint` and ´kyvejs/tendermint-ssync` pool on `kaon-1`.