### PR TITLE
update: Cronos mainnet pools.

### DIFF
--- a/cronosmainnet_25-1/config.yml
+++ b/cronosmainnet_25-1/config.yml
@@ -5,7 +5,9 @@ source:
   hex: "#191b34"
 
 # Mainnet pools
-kyve-1: {}
+kyve-1:
+  block_pool_id: 5
+  state_pool_id: 6
 
 # Testnet pools
 kaon-1:


### PR DESCRIPTION
This PR registers the Mainnet pools for `cronosmainnet_25-1`.

https://app.kyve.network/#/governance/20