### PR TITLE
Update config.yml

### DIFF
--- a/cosmoshub-4/config.yml
+++ b/cosmoshub-4/config.yml
@@ -146,7 +146,7 @@ codebase:
         recommended-version: "v20.0.0"
         commit: "2dba9d471ef73b0a99e844bf55a44ddae700ea06"
         go-version: "go1.22"
-        ksync-engine: "cometbft-v0.37"
+        ksync-engine: "cometbft-v0.38"
         cosmos-sdk-version: "v0.50.9-lsm"
 
 networks:


### PR DESCRIPTION
CosmosHub has cometbft-v0.38 starting from v19.
I was not able to start "ksync serve-snapshots" without explicit usage of "--engine cometbft-v0.38" 